### PR TITLE
fix: build full scan_url in collection and creature detail endpoints

### DIFF
--- a/BackEnd/src/main/controllers/userController.js
+++ b/BackEnd/src/main/controllers/userController.js
@@ -266,6 +266,7 @@ exports.getUserCreatures = async (req, res) => {
         // Note: Chemin relatif, le front sait que c'est /models/{model_path}
         const creaturesWithModels = result.rows.map(creature => ({
             ...creature, // On conserve l'intégralité des données d'origine (id, stats, etc.)
+            scan_url: buildScanUrl(req, creature.scan_url),
             // URL relative au domaine (optimisé pour cache HTTP et CDN)
             model_url: creature.species_model_path ? `/models/${creature.species_model_path}` : null
         }));
@@ -299,7 +300,12 @@ exports.getUserPlants = async (req, res) => {
 
         const result = await db.query(query, [userId]);
 
-        res.json(result.rows);
+        const plantsWithUrls = result.rows.map(row => ({
+            ...row,
+            scan_url: buildScanUrl(req, row.scan_url)
+        }));
+
+        res.json(plantsWithUrls);
     } catch (err) {
         console.error('Erreur lors de la récupération des plantes:', err);
         res.status(500).json({ error: "Erreur lors de la récupération des plantes." });
@@ -339,6 +345,7 @@ exports.getUserCreatureDetails = async(req, res) => {
          // Assemblage de l'objet de retour
          const creatureDetails = {
              ...creature,
+             scan_url: buildScanUrl(req, creature.scan_url),
              model_url: creature.species_model_path ? `/models/${creature.species_model_path}` : null
          };
 

--- a/BackEnd/src/tests/controllers/userController.test.js
+++ b/BackEnd/src/tests/controllers/userController.test.js
@@ -210,7 +210,7 @@ describe('userController', () => {
                     id: 'c-1',
                     species_name: 'Alpaca',
                     species_model_path: 'alpaca',
-                    scan_url: 'scan1.jpg', // scan_url est renvoyé tel quel de la DB
+                    scan_url: 'http://localhost:3001/uploads/scan1.jpg', // URL publique reconstruite par buildScanUrl
                     model_url: '/models/alpaca' // model_url est généré
                 },
                 {
@@ -247,7 +247,8 @@ describe('userController', () => {
                 {
                     id: 'c-2',
                     species_name: 'Fougère',
-                    species_model_path: null
+                    species_model_path: null,
+                    scan_url: null // ajouté par buildScanUrl (null car absent de la DB)
                 }
             ];
 
@@ -395,7 +396,7 @@ describe('userController', () => {
                 id: 'c-99',
                 species_name: 'Lion',
                 species_model_path: 'lion',
-                scan_url: 'lion_scan.jpg', // scan_url est renvoyé tel quel de la DB
+                scan_url: 'http://localhost:3001/uploads/lion_scan.jpg', // URL publique reconstruite par buildScanUrl
                 model_url: '/models/lion' // model_url est généré
             };
 


### PR DESCRIPTION
Les routes getUserCreatures, getUserCreatureDetails et getUserPlants renvoyaient le scan_url brut (nom de fichier) au lieu de l'URL publique, ce qui empêchait l'affichage des images dans la collection alors que le feed fonctionnait déjà via getLastCapturedCreatures.