### PR TITLE
fix: images manquantes dans la collection

### DIFF
--- a/BackEnd/src/main/controllers/userController.js
+++ b/BackEnd/src/main/controllers/userController.js
@@ -207,6 +207,7 @@ exports.getUserCreatures = async (req, res) => {
         // Note: Chemin relatif, le front sait que c'est /models/{model_path}
         const creaturesWithModels = result.rows.map(creature => ({
             ...creature,
+            scan_url: buildScanUrl(req, creature.scan_url),
             model_url: creature.species_model_path ? `/models/${creature.species_model_path}` : null
         }));
 

--- a/BackEnd/src/tests/controllers/userController.test.js
+++ b/BackEnd/src/tests/controllers/userController.test.js
@@ -155,6 +155,7 @@ describe('userController', () => {
                 id: 'c-1',
                 species_name: 'Alpaca',
                 species_model_path: 'alpaca',
+                scan_url: null,
                 model_url: '/models/alpaca'
             }];
             expect(res.json).toHaveBeenCalledWith(expectedPayload);


### PR DESCRIPTION
getUserCreatures ne reconstruisait pas l'URL publique du scan_url contrairement aux autres endpoints (plants, creature details, feed). Le front recevait le nom de fichier brut au lieu de l'URL complete.